### PR TITLE
feature: Add no_std mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
       - uses: Swatinem/rust-cache@v1
       - name: Build & run tests
         run: cargo test --all-features
+      - name: Build & run tests without libstd
+        run: cargo test --no-default-features
+      - name: Build & run tests without libstd, but with serde
+        run: cargo test --no-default-features --features serde
   miri:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,13 @@ categories = ["data-structures"]
 keywords = ["vector", "linked", "list"]
 
 [dependencies]
-serde = { version = "1", optional = true }
+const-random = "0.1.15"
+serde = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 coverage-helper = "0.1.0"
 serde_test = "1.0.144"
+
+[features]
+default = ["std"]
+std = []

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Semi-doubly linked list implemented using a vector.
 
 # Features
 
+ - `std` (default) enables usage of `libstd`, disabling this feature will make the crate `no_std` compatible.
  - `serde` for (de)serialization.
 
 ## License

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,4 +1,4 @@
-use std::{
+use core::{
   fmt::{self, Formatter},
   marker::PhantomData,
 };


### PR DESCRIPTION
This PR adds a new default `std` feature that, when disabled, allows this crate to be used on `no_std` targets.

This is a breaking change.