### PR TITLE
Move `const-random` dependency behind a feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,12 @@ jobs:
           toolchain: nightly
           override: true
       - uses: Swatinem/rust-cache@v2
-      - name: Build & run tests
-        run: cargo test --all-features
+      - name: Build & run tests for default and serde features
+        run: cargo test --features std,serde
       - name: Build & run tests without libstd
-        run: cargo test --no-default-features
+        run: cargo test --no-default-features --features const-random
       - name: Build & run tests without libstd, but with serde
-        run: cargo test --no-default-features --features serde
+        run: cargo test --no-default-features --features const-random,serde
   miri:
     runs-on: ubuntu-latest
     steps:
@@ -32,8 +32,12 @@ jobs:
           toolchain: nightly
           components: miri
           override: true
-      - name: Test with Miri
-        run: cargo miri test --all-features
+      - name: Test with Miri, default and serde features
+        run: cargo miri test --features std,serde
+      - name: Test with Miri, without libstd
+        run: cargo miri test --no-default-features --features const-random
+      - name: Test with Miri, without libstd but with serde
+        run: cargo miri test --no-default-features --features const-random,serde
   mutation:
     runs-on: ubuntu-latest
     steps:
@@ -67,7 +71,9 @@ jobs:
           override: true
       - uses: Swatinem/rust-cache@v2
       - name: Run clippy
-        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+        run: cargo clippy --workspace --all-targets --features std,serde -- -D warnings
+      - name: Run clippy for const-random feature
+        run: cargo clippy --workspace --all-targets --no-default-features --features const-random -- -D warnings
       - name: Check format
         run: cargo fmt --all -- --check
   coverage:
@@ -85,9 +91,11 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate code coverage
-        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+        run: cargo llvm-cov --features std,serde --workspace --lcov --output-path lcov.info
+      - name: Generate code coverage for no_std
+        run: cargo llvm-cov --no-default-features --features const-random --workspace --lcov --output-path lcov_nostd.info
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
-          files: lcov.info
+          files: lcov.info,lcov_nostd.info
           fail_ci_if_error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+
+ - Moved `const-random` dependency behind a feature (only used for no_std environments) - @zmrow
+
 ## [0.5.2] - 2023-10-24
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,13 +48,15 @@ cargo test
 - Run Clippy:
 
   ```shell
-  cargo clippy --all-targets --all-features --workspace
+  cargo clippy --all-targets --workspace --features std,serde
+  cargo clippy --all-targets --workspace --features const-random --no-default-features
   ```
 
 - Run all tests:
 
   ```shell
-  cargo test --all-features --workspace
+  cargo test --features std,serde --workspace
+  cargo test --features const-random --no-default-features --workspace
   ```
 
 - Check to see if there are code formatting issues

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["data-structures"]
 keywords = ["vector", "linked", "list"]
 
 [dependencies]
-const-random = "0.1.15"
+const-random = { version = "0.1.15", optional = true }
 serde = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
@@ -21,3 +21,4 @@ serde_test = "1.0.144"
 [features]
 default = ["std"]
 std = []
+const-random = ["dep:const-random"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Semi-doubly linked list implemented using a vector.
 
 # Features
 
- - `std` (default) enables usage of `libstd`, disabling this feature will make the crate `no_std` compatible.
+ - `std` (default) enables usage of `libstd`, disabling this feature and enabling the `const-random` feature will make the crate `no_std` compatible.
+ - `const-random` enables the `const-random` dependency, making the crate suitable for `no_std` (along with disabling default features)
  - `serde` for (de)serialization.
 
 ## License

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,11 +5,15 @@
 //! # Features
 //!
 //! By default, this crate uses the Rust standard library. To disable this, disable the default
-//! `no_std` feature. Without this feature, certain methods will not be available.
+//! `std` feature, and enable the `const-random` feature. Without these features, certain methods
+//! will not be available.
 
 #![allow(unsafe_code)]
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
+
+#[cfg(all(feature = "std", feature = "const-random"))]
+compile_error!("default feature 'std' and feature 'const-random' cannot be enabled at the same time: for no_std environments, disable 'std' and enable 'const-random'");
 
 extern crate alloc;
 


### PR DESCRIPTION
Fixes #22 

### Summary

 `const-random` is only used in no_std environments, and even though std is the default for the crate, the dependency was being brought in regardless.  This change moves the `const-random` dependency behind a feature with the same name.  Since cargo doesn't provide a way to make features mutually exclusive, a `compile_err` is added to the code to ensure it does not compile in the event `std` and `const-random` features are both enabled.

For all users of the default feature set, this is a non-breaking change.  For users that need to use the dependency in no_std environments, they will now need to turn off the default features and enable the `const-random` feature.

### Testing

Per the contributing guide:
* All unit tests continue to pass
* Clippy and fmt are happy
* Cargo tree correctly reports the proper dependencies being pulled in for default, const-random, and serde
```
$ cargo tree --features serde
dlv-list v0.5.2 (REDACTED)
└── serde v1.0.214
[dev-dependencies]
├── coverage-helper v0.2.2 (proc-macro)
└── serde_test v1.0.177
    └── serde v1.0.214

$ cargo tree --features const-random
dlv-list v0.5.2 (REDACTED)
└── const-random v0.1.18
    └── const-random-macro v0.1.16 (proc-macro)
        ├── getrandom v0.2.15
        │   ├── cfg-if v1.0.0
        │   └── libc v0.2.161
        ├── once_cell v1.20.2
        └── tiny-keccak v2.0.2
            └── crunchy v0.2.2
[dev-dependencies]
├── coverage-helper v0.2.2 (proc-macro)
└── serde_test v1.0.177
    └── serde v1.0.214

$ cargo tree
dlv-list v0.5.2 (REDACTED)
[dev-dependencies]
├── coverage-helper v0.2.2 (proc-macro)
└── serde_test v1.0.177
    └── serde v1.0.214
```
