### PR TITLE
Drop coverage-helper dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ const-random = { version = "0.1.15", optional = true }
 serde = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-coverage-helper = "0.2.0"
 serde_test = "1.0.144"
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2283,8 +2283,8 @@ fn create_initial_generation() -> u64 {
 
 #[allow(unused_results)]
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod test {
-  use coverage_helper::test;
 
   use super::*;
   use alloc::{format, vec};

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -67,8 +67,8 @@ where
 
 #[allow(unused_results)]
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod test {
-  use coverage_helper::test;
   use serde_test::{assert_de_tokens_error, assert_tokens, Token};
 
   use super::*;


### PR DESCRIPTION
As indicated in the upstream readme, `coverage-helper` is deprecated and should be replaced with built-in patterns.